### PR TITLE
Fix error when firing menu Laf chnage to metal

### DIFF
--- a/src/org/tmpotter/ui/MenuHandler.java
+++ b/src/org/tmpotter/ui/MenuHandler.java
@@ -404,7 +404,7 @@ final class MenuHandler {
     onChangeLnF(MenuHandler.LnfType.LIQUID);
   }
 
-  public void menuLafMetalActionPerformed() {
+  public void menuItemLafMetalActionPerformed() {
     onChangeLnF(MenuHandler.LnfType.METAL);
   }
 


### PR DESCRIPTION
Fix typo to fix following error.
[java] Exception in thread "AWT-EventQueue-0" java.lang.IncompatibleClassChangeError: Error invoke method handler for main menu: there is no method menuItemLafMetalActionPerformed

Signed-off-by: Hiroshi Miura miurahr@linux.com
